### PR TITLE
ci: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "09:00"
+      timezone: Asia/Tokyo
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '09:00'
+      timezone: Asia/Tokyo


### PR DESCRIPTION
I add `Dependabot` for checking the versions of dependencies.

- Document: https://docs.github.com/en/code-security/dependabot/working-with-dependabot

Closes: https://github.com/fixstars/amplify-benchmark-viewer-test/issues/9